### PR TITLE
change text domain to match translation files

### DIFF
--- a/rpwe.php
+++ b/rpwe.php
@@ -7,7 +7,7 @@
  * Author:       Satrya
  * Author URI:   https://www.theme-junkie.com/
  * Author Email: support@theme-junkie.com
- * Text Domain:  recent-posts-widget-extended
+ * Text Domain:  rpwe
  * Domain Path:  /languages
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the GNU


### PR DESCRIPTION
Translation files work only if the translation files names match the plugin text domain.
